### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A *Makefile* is included to help automate the building process.
 ## Who can benefit from this?
 
 Author of an open-source Swift 3 library. The library is distributed with any
-combination of Cocoapods, Carthage and Swift Package Manager. They want to
+combination of CocoaPods, Carthage and Swift Package Manager. They want to
 ensure supports for them keep working throughout development.
 
 ## How does it work?
@@ -40,7 +40,7 @@ a consistent name for the framework file (`Just`.framework) and import symbol
 build`Just-tvOS.framework` but user writes `import Just` in their code, that
 won't work.
 
-Out of the box, all three package managers (Cocoapods, Carthage, Swift Package
+Out of the box, all three package managers (CocoaPods, Carthage, Swift Package
 Manager) and four platforms (iOS, macOS, watchOS, tvOS) are tested.
 
 Swift package manager projects tests against a major version number.


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
